### PR TITLE
Fix the StreamInfo and MediaInfo clone

### DIFF
--- a/mediainfo.go
+++ b/mediainfo.go
@@ -56,6 +56,8 @@ func (m *MediaInfo) Clone() *MediaInfo {
 	if m.simulcast {
 		cloned.SetSimulcast(m.simulcast)
 	}
+	cloned.Protocal = m.Protocal
+	cloned.Payloads = m.Payloads
 	return cloned
 }
 

--- a/streaminfo.go
+++ b/streaminfo.go
@@ -23,8 +23,8 @@ func (s *StreamInfo) Clone() *StreamInfo {
 		tracks: make([]*TrackInfo, 0),
 	}
 
-	for k, v := range s.tracks {
-		stream.tracks[k] = v.Clone()
+	for _, v := range s.tracks {
+		stream.tracks = append(stream.tracks, v.Clone())
 	}
 	return stream
 }
@@ -40,20 +40,20 @@ func (s *StreamInfo) AddTrack(track *TrackInfo) {
 }
 
 func (s *StreamInfo) RemoveTrack(track *TrackInfo) {
-	tracks := make([]*TrackInfo,0)
-	for _,temtrack := range s.tracks {
+	tracks := make([]*TrackInfo, 0)
+	for _, temtrack := range s.tracks {
 		if temtrack.GetID() != track.GetID() {
-			tracks = append(tracks,temtrack)
+			tracks = append(tracks, temtrack)
 		}
 	}
 	s.tracks = tracks
 }
 
 func (s *StreamInfo) RemoveTrackById(trackId string) {
-	tracks := make([]*TrackInfo,0)
-	for _,temtrack := range s.tracks {
+	tracks := make([]*TrackInfo, 0)
+	for _, temtrack := range s.tracks {
 		if temtrack.GetID() != trackId {
-			tracks = append(tracks,temtrack)
+			tracks = append(tracks, temtrack)
 		}
 	}
 	s.tracks = tracks
@@ -77,12 +77,12 @@ func (s *StreamInfo) GetTracks() []*TrackInfo {
 
 func (s *StreamInfo) RemoveAllTracks() {
 
-	s.tracks = make([]*TrackInfo,0)
+	s.tracks = make([]*TrackInfo, 0)
 }
 
 func (s *StreamInfo) GetTrack(trackID string) *TrackInfo {
 
-	for _,track := range s.tracks {
+	for _, track := range s.tracks {
 		if track.GetID() == trackID {
 			return track
 		}


### PR DESCRIPTION
修复了MediaInfo.clone()，丢失Protocal和Payloads属性。
修复了StreamInfo.clone()，访问stream.tracks[0]会导致Panic越界的bug：
```
"runtime error: index out of range [0] with length 0"
```